### PR TITLE
Compatibility with webpack-dev-server

### DIFF
--- a/EncodingPlugin.js
+++ b/EncodingPlugin.js
@@ -1,23 +1,60 @@
 var fs = require('fs');
-
+var RawSource = require('webpack-sources').RawSource;
+var SourceMapSource = require('webpack-sources').SourceMapSource;
 var encoding = require('encoding');
+var ModuleFilenameHelpers = require('webpack').ModuleFilenameHelpers;
+if (!ModuleFilenameHelpers) {
+    // See https://github.com/webpack/webpack/issues/2640
+    ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
+}
 
 function EncodingPlugin(options) {
-    this.encoding = options;
+    if (typeof options === 'string') {
+        this.options = {
+            encoding: options
+        };
+    } else {
+        this.options = options || {};
+    }
 }
 
 EncodingPlugin.prototype.apply = function (compiler) {
-    var targetEncoding = this.encoding;
-    compiler.plugin('after-emit', function (compilation, callback) {
+    var options = this.options;
+    options.test = options.test || /(\.js|\.css)($|\?)/i;
 
-        for (assetName in compilation.assets) {
-            var asset = compilation.assets[assetName];
-            var converted = encoding.convert(asset.source(), targetEncoding, 'UTF-8');
-            fs.writeFileSync(asset.existsAt, converted);
-        }
-        console.log('Assets converted to ' + targetEncoding);
+    var matchFileName = ModuleFilenameHelpers.matchObject.bind(undefined, options);
+
+    compiler.plugin('emit', function(compilation, callback) {
+        var files = Object.keys(compilation.assets).filter(matchFileName);
+        files.forEach(function(file) {
+            var asset = compilation.assets[file];
+            try {
+                var source, map;
+                if (asset.sourceAndMap) {
+                    var sourceAndMap = asset.sourceAndMap();
+                    source = sourceAndMap.source;
+                    map = sourceAndMap.map;
+                } else {
+                    source = asset.source();
+                    map = asset.map();
+                }
+
+                var encodedSource = encoding.convert(source, options.encoding, 'UTF-8');
+                if (asset.existsAt && fs.existsSync(asset.existsAt)) {
+                    fs.writeFileSync(asset.existsAt, encodedSource);
+                }
+
+                compilation.assets[file] = map ?
+                  new SourceMapSource(encodedSource, file, map) :
+                  new RawSource(encodedSource);
+
+            } catch (e) {
+                compilation.errors.push(new Error(file + ' from EncodingPlugin: ' + e.message));
+            }
+        });
+
+        console.log('Assets converted to ' + options.encoding);
         callback();
-
     });
 };
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webpack Encoding Plugin
 
-Take contol over the encoding of emitted webpack assets.
+Take control over the encoding of emitted webpack assets.
 This can be useful, if the delivering webserver enforces a specific content-type, 
 so that your js-code is not interpreted as utf-8 by the browser.
 
@@ -20,9 +20,16 @@ module.exports = {
         path: '../dist',
         filename: 'bundle.js'
     },
-    plugins: [new encodingPlugin('iso-8859-1')]
+    plugins: [new encodingPlugin({
+      encoding: 'iso-8859-1'
+    })]
 };
 ```
+
+Additional options:
+
+`test`, `include`, `exclude` RegExp or array of RegExps to filter processed files
+(default `test` is `/(\.js|\.css)($|\?)/i`)
 
 ## Encodings
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "author": "Tobias Wingerter <tobias@quackes.de>",
   "license": "MIT",
   "devDependencies": {
-    "webpack": "^1.12.4"
+    "webpack": "^1.12.4",
+    "webpack-sources": "^0.1.2"
   },
   "dependencies": {
     "encoding": "^0.1.11"


### PR DESCRIPTION
- Now the constructor receives an options argument instead of a string. This change is needed to receive the "test", "include" e "exclude" properties, similar to another plugins like UglifyPlugin. For default the plugin only will encode js and css files. Before this change it encoded assets like images and intermediate assets of another plugins. It was preserved the compatibility with a single string argument.
- The bundling pipeline can be executed in-memory without write any asset to the disk. In this mode webpack-encoding-plugin failed when trying to access an invalid file path. An example is the webpack-dev-server bundling. See https://github.com/webpack/webpack-dev-server/issues/62 for more details.
