### PR TITLE
check that asset.map is a function before call it

### DIFF
--- a/EncodingPlugin.js
+++ b/EncodingPlugin.js
@@ -36,7 +36,9 @@ EncodingPlugin.prototype.apply = function (compiler) {
                     map = sourceAndMap.map;
                 } else {
                     source = asset.source();
-                    map = asset.map();
+                    map = typeof asset.map === 'function' ?
+                        asset.map() :
+                        null;
                 }
 
                 var encodedSource = encoding.convert(source, options.encoding, 'UTF-8');


### PR DESCRIPTION
Some assets do not have .map() method.
Here https://github.com/kevlened/copy-webpack-plugin/blob/a59ba168a4d46bd5a1c82fddac6b6ee6452d7799/src/writeFile.js#L84-L91 plugin adds new assets that have only .source() and .size() methods. They cause errors when precessed with EncodingPlugin.